### PR TITLE
Add shared TypeScript types and tournament scoring constants

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,41 @@
+import type { Region, RoundNumber } from './types'
+
+export const ROUND_POINTS: Record<RoundNumber, number> = {
+  1: 10,    // Round of 64
+  2: 20,    // Round of 32
+  3: 40,    // Sweet 16
+  4: 80,    // Elite 8
+  5: 160,   // Final Four
+  6: 320,   // Championship
+}
+
+export const ROUND_NAMES: Record<RoundNumber, string> = {
+  1: 'Round of 64',
+  2: 'Round of 32',
+  3: 'Sweet 16',
+  4: 'Elite 8',
+  5: 'Final Four',
+  6: 'Championship',
+}
+
+export const REGIONS: Region[] = ['east', 'west', 'midwest', 'south']
+
+export const REGION_NAMES: Record<Region, string> = {
+  east: 'East',
+  west: 'West',
+  midwest: 'Midwest',
+  south: 'South',
+}
+
+export const TOTAL_GAMES = 63
+export const TOTAL_TEAMS = 64
+export const GAMES_PER_REGION_ROUND: Record<RoundNumber, number> = {
+  1: 8,
+  2: 4,
+  3: 2,
+  4: 1,
+  5: 0,
+  6: 0,
+}
+
+export const MAX_POSSIBLE_SCORE = 1920

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,105 @@
+export interface Team {
+  id: number
+  name: string
+  short_name: string
+  seed: number
+  region: Region
+  logo_url: string | null
+}
+
+export type Region = 'east' | 'west' | 'midwest' | 'south'
+
+export type RoundNumber = 1 | 2 | 3 | 4 | 5 | 6
+
+export interface Game {
+  id: number
+  round: RoundNumber
+  region: Region | null
+  position: number
+  team1_id: number | null
+  team2_id: number | null
+  feed_game_1_id: number | null
+  feed_game_2_id: number | null
+  winner_id: number | null
+  scheduled_at: string | null
+}
+
+export interface Agent {
+  id: string
+  name: string
+  api_key?: string  // only included in registration response
+  avatar_url: string | null
+  description: string | null
+  created_at: string
+}
+
+export interface Bracket {
+  id: string
+  agent_id: string
+  name: string
+  score: number
+  max_possible_score: number
+  rank: number | null
+  tiebreaker: number | null
+  created_at: string
+}
+
+export interface Pick {
+  id: number
+  bracket_id: string
+  game_id: number
+  predicted_winner_id: number
+  is_correct: boolean | null
+  points_earned: number
+}
+
+export interface TournamentConfig {
+  id: number
+  year: number
+  name: string
+  submission_deadline: string
+  status: 'upcoming' | 'active' | 'completed'
+}
+
+// API request/response types
+export interface RegisterAgentRequest {
+  name: string
+  description?: string
+}
+
+export interface RegisterAgentResponse {
+  id: string
+  name: string
+  api_key: string
+}
+
+export interface SubmitBracketRequest {
+  name: string
+  tiebreaker: number
+  picks: { game_id: number; winner_id: number }[]
+}
+
+export interface BracketWithAgent extends Bracket {
+  agent: Pick<Agent, 'id' | 'name' | 'avatar_url'>
+}
+
+export interface LeaderboardEntry extends BracketWithAgent {
+  picks_correct: number
+  picks_total: number
+}
+
+export interface TournamentData {
+  config: TournamentConfig
+  teams: Team[]
+  games: GameWithTeams[]
+}
+
+export interface GameWithTeams extends Game {
+  team1: Team | null
+  team2: Team | null
+}
+
+export interface BracketDetail extends Bracket {
+  agent: Pick<Agent, 'id' | 'name' | 'avatar_url' | 'description'>
+  picks: (Pick & { predicted_winner: Team })[]
+}


### PR DESCRIPTION
## Summary
- Define TypeScript interfaces mirroring all 6 database tables
- Add API request/response types for registration and bracket submission
- Add ESPN-style scoring constants (10/20/40/80/160/320 per round, max 1920)

Part of plan: agent-march-madness-bracket.md (PR 3 of 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)