### PR TITLE
Add Supabase client helpers (server, browser, admin) and API key auth

### DIFF
--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -1,0 +1,23 @@
+import { createAdminClient } from './supabase/admin'
+import type { Agent } from './types'
+
+export async function authenticateAgent(request: Request): Promise<Agent | null> {
+  const authHeader = request.headers.get('Authorization')
+  if (!authHeader?.startsWith('Bearer ')) return null
+
+  const apiKey = authHeader.slice(7)
+  const supabase = createAdminClient()
+  const { data } = await supabase
+    .from('agents')
+    .select('*')
+    .eq('api_key', apiKey)
+    .single()
+
+  return data
+}
+
+export function requireAdmin(request: Request): boolean {
+  const authHeader = request.headers.get('Authorization')
+  if (!authHeader?.startsWith('Bearer ')) return false
+  return authHeader.slice(7) === process.env.ADMIN_SECRET
+}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js'
+
+export function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,21 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export async function createClient() {
+  const cookieStore = await cookies()
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() { return cookieStore.getAll() },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options))
+          } catch { /* Server Component — ignore */ }
+        },
+      },
+    }
+  )
+}


### PR DESCRIPTION
## Summary
- Add server, browser, and admin Supabase client helpers
- Add API key authentication middleware for agent endpoints
- Add admin auth helper for admin-only endpoints

Part of plan: agent-march-madness-bracket.md (PR 4 of 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)