### PR TITLE
Add leaderboard page with Supabase Realtime subscriptions

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,105 @@
+import { Metadata } from "next";
+import { createClient } from "@/lib/supabase/server";
+import LeaderboardTable from "@/components/leaderboard-table";
+import type { LeaderboardEntry } from "@/lib/types";
+
+export const metadata: Metadata = {
+  title: "Leaderboard | Agent Madness",
+  description:
+    "Live leaderboard for the AI March Madness Bracket Challenge. See which agents are leading the competition.",
+};
+
+export default async function LeaderboardPage() {
+  const supabase = await createClient();
+
+  // Fetch brackets joined with agents, ordered by score DESC
+  const { data: brackets } = await supabase
+    .from("brackets")
+    .select("*, agent:agents(id, name, avatar_url)")
+    .order("score", { ascending: false });
+
+  let entries: LeaderboardEntry[] = [];
+
+  if (brackets && brackets.length > 0) {
+    // Fetch pick counts per bracket
+    const bracketIds = brackets.map((b) => b.id);
+    const { data: picks } = await supabase
+      .from("picks")
+      .select("bracket_id, is_correct")
+      .in("bracket_id", bracketIds);
+
+    const pickCounts = new Map<
+      string,
+      { correct: number; total: number }
+    >();
+
+    if (picks) {
+      for (const pick of picks) {
+        const existing = pickCounts.get(pick.bracket_id) ?? {
+          correct: 0,
+          total: 0,
+        };
+        existing.total += 1;
+        if (pick.is_correct === true) existing.correct += 1;
+        pickCounts.set(pick.bracket_id, existing);
+      }
+    }
+
+    entries = brackets.map((bracket) => {
+      const counts = pickCounts.get(bracket.id) ?? {
+        correct: 0,
+        total: 0,
+      };
+      return {
+        ...bracket,
+        agent: Array.isArray(bracket.agent) ? bracket.agent[0] : bracket.agent,
+        picks_correct: counts.correct,
+        picks_total: counts.total,
+      } as LeaderboardEntry;
+    });
+  }
+
+  return (
+    <main className="min-h-screen px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-5xl">
+        <div className="mb-10">
+          <h1 className="text-3xl font-bold text-text-primary sm:text-4xl">
+            Leaderboard
+          </h1>
+          <p className="mt-2 text-text-secondary">
+            Live rankings of AI agents competing in the 2026 March Madness
+            Bracket Challenge.
+          </p>
+        </div>
+
+        {entries.length > 0 ? (
+          <LeaderboardTable initialData={entries} />
+        ) : (
+          <div className="flex flex-col items-center justify-center rounded-xl border border-white/5 bg-bg-card py-20">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-court-green/10">
+              <svg
+                className="h-8 w-8 text-court-green"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M16.5 18.75h-9m9 0a3 3 0 013 3h-15a3 3 0 013-3m9 0v-4.5A3.375 3.375 0 0019.875 10.875h0A3.375 3.375 0 0016.5 7.5V3.75m-9 15v-4.5A3.375 3.375 0 004.125 10.875h0A3.375 3.375 0 007.5 7.5V3.75m0 0h9m-9 0H6a2.25 2.25 0 00-2.25 2.25v0A2.25 2.25 0 006 8.25h1.5m9-4.5H18a2.25 2.25 0 012.25 2.25v0A2.25 2.25 0 0118 8.25h-1.5"
+                />
+              </svg>
+            </div>
+            <p className="text-lg font-medium text-text-primary">
+              No brackets submitted yet
+            </p>
+            <p className="mt-1 text-sm text-text-secondary">
+              Be the first to enter the competition!
+            </p>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/components/leaderboard-table.tsx
+++ b/src/components/leaderboard-table.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import type { LeaderboardEntry } from "@/lib/types";
+
+interface LeaderboardTableProps {
+  initialData: LeaderboardEntry[];
+}
+
+async function fetchLeaderboard(
+  supabase: ReturnType<typeof createClient>
+): Promise<LeaderboardEntry[]> {
+  // Fetch brackets joined with agents, ordered by score DESC
+  const { data: brackets, error } = await supabase
+    .from("brackets")
+    .select("*, agent:agents(id, name, avatar_url)")
+    .order("score", { ascending: false });
+
+  if (error || !brackets) return [];
+
+  // Fetch pick counts per bracket
+  const bracketIds = brackets.map((b) => b.id);
+  const { data: picks } = await supabase
+    .from("picks")
+    .select("bracket_id, is_correct")
+    .in("bracket_id", bracketIds);
+
+  const pickCounts = new Map<
+    string,
+    { correct: number; total: number }
+  >();
+
+  if (picks) {
+    for (const pick of picks) {
+      const existing = pickCounts.get(pick.bracket_id) ?? {
+        correct: 0,
+        total: 0,
+      };
+      existing.total += 1;
+      if (pick.is_correct === true) existing.correct += 1;
+      pickCounts.set(pick.bracket_id, existing);
+    }
+  }
+
+  return brackets.map((bracket) => {
+    const counts = pickCounts.get(bracket.id) ?? {
+      correct: 0,
+      total: 0,
+    };
+    return {
+      ...bracket,
+      agent: Array.isArray(bracket.agent) ? bracket.agent[0] : bracket.agent,
+      picks_correct: counts.correct,
+      picks_total: counts.total,
+    } as LeaderboardEntry;
+  });
+}
+
+const MEDAL_STYLES: Record<number, string> = {
+  0: "text-yellow-400", // gold
+  1: "text-gray-300",   // silver
+  2: "text-amber-600",  // bronze
+};
+
+const MEDAL_BG: Record<number, string> = {
+  0: "bg-yellow-400/5 border-l-2 border-l-yellow-400/40",
+  1: "bg-gray-300/5 border-l-2 border-l-gray-300/30",
+  2: "bg-amber-600/5 border-l-2 border-l-amber-600/30",
+};
+
+export default function LeaderboardTable({
+  initialData,
+}: LeaderboardTableProps) {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>(initialData);
+  const [isLive, setIsLive] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    // Subscribe to brackets table changes via Supabase Realtime
+    const channel = supabase
+      .channel("leaderboard-realtime")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "brackets" },
+        () => {
+          // On any change to brackets, refetch leaderboard data
+          fetchLeaderboard(supabase).then((data) => {
+            if (data.length > 0) setEntries(data);
+          });
+        }
+      )
+      .subscribe((status) => {
+        setIsLive(status === "SUBSCRIBED");
+      });
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, []);
+
+  return (
+    <div>
+      {/* Live indicator */}
+      <div className="mb-6 flex items-center gap-2">
+        <span
+          className={`inline-block h-2.5 w-2.5 rounded-full ${
+            isLive ? "bg-green-500 animate-pulse" : "bg-text-secondary"
+          }`}
+        />
+        <span
+          className={`text-xs font-semibold uppercase tracking-wider ${
+            isLive ? "text-green-500" : "text-text-secondary"
+          }`}
+        >
+          {isLive ? "Live" : "Connecting..."}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-xl border border-white/5">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b border-white/5 bg-bg-dark">
+                <th className="px-4 py-4 text-xs font-semibold uppercase tracking-wider text-text-secondary sm:px-6">
+                  Rank
+                </th>
+                <th className="px-4 py-4 text-xs font-semibold uppercase tracking-wider text-text-secondary sm:px-6">
+                  Agent Name
+                </th>
+                <th className="px-4 py-4 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary sm:px-6">
+                  Score
+                </th>
+                <th className="hidden px-4 py-4 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary sm:table-cell sm:px-6">
+                  Max Possible
+                </th>
+                <th className="hidden px-4 py-4 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary sm:table-cell sm:px-6">
+                  Correct Picks
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {entries.map((entry, index) => {
+                const isTopThree = index < 3;
+                const medalColor = MEDAL_STYLES[index] ?? "";
+                const medalBg = MEDAL_BG[index] ?? "";
+
+                return (
+                  <tr
+                    key={entry.id}
+                    className={`transition-colors hover:bg-white/[0.03] ${
+                      isTopThree ? medalBg : index % 2 === 1 ? "bg-white/[0.01]" : ""
+                    }`}
+                  >
+                    <td className="px-4 py-3.5 sm:px-6">
+                      <span
+                        className={`text-sm font-bold ${
+                          isTopThree ? medalColor : "text-text-secondary"
+                        }`}
+                      >
+                        {index + 1}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3.5 sm:px-6">
+                      <Link
+                        href={`/brackets/${entry.id}`}
+                        className="group flex items-center gap-3"
+                      >
+                        {entry.agent.avatar_url ? (
+                          <img
+                            src={entry.agent.avatar_url}
+                            alt={entry.agent.name}
+                            className="h-8 w-8 rounded-full object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-court-green/20 text-xs font-bold text-court-green">
+                            {entry.agent.name.charAt(0).toUpperCase()}
+                          </div>
+                        )}
+                        <span
+                          className={`text-sm font-medium transition-colors group-hover:text-court-orange ${
+                            isTopThree ? "text-text-primary" : "text-text-primary"
+                          }`}
+                        >
+                          {entry.agent.name}
+                        </span>
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3.5 text-right sm:px-6">
+                      <span
+                        className={`text-sm font-semibold ${
+                          isTopThree ? "text-court-orange" : "text-text-primary"
+                        }`}
+                      >
+                        {entry.score.toLocaleString()}
+                      </span>
+                    </td>
+                    <td className="hidden px-4 py-3.5 text-right sm:table-cell sm:px-6">
+                      <span className="text-sm text-text-secondary">
+                        {entry.max_possible_score.toLocaleString()}
+                      </span>
+                    </td>
+                    <td className="hidden px-4 py-3.5 text-right sm:table-cell sm:px-6">
+                      <span className="text-sm text-text-secondary">
+                        {entry.picks_correct}/{entry.picks_total}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Server-rendered leaderboard with initial data fetch
- Client-side Realtime subscription for live score updates
- Top 3 medal styling, LIVE connection indicator
- Links to bracket detail pages

Part of plan: agent-march-madness-bracket.md (PR 12 of 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)