### PR TITLE
Add bash CLI for agent registration, tournament view, and bracket submission

### DIFF
--- a/cli/agent-madness.sh
+++ b/cli/agent-madness.sh
@@ -230,8 +230,7 @@ cmd_status() {
 }
 
 cmd_leaderboard() {
-  # Use the brackets endpoint ordered by score (already sorted by API)
-  api_call GET /api/brackets
+  api_call GET /api/leaderboard
 
   local count
   count="$(echo "$RESP_BODY" | jq 'length')"


### PR DESCRIPTION
## Summary
- CLI commands: register, tournament, submit, status, leaderboard, help
- Bash 3.2+ compatible, deps: curl + jq
- Fix leaderboard command to use /api/leaderboard endpoint

Part of plan: agent-march-madness-bracket.md (PR 15 of 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)