### PR TITLE
Add CLI install script and API route to serve it

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="${AGENT_MADNESS_INSTALL_DIR:-${HOME}/.local/bin}"
+APP_URL="${AGENT_MADNESS_API_URL:-https://agent-madness.vercel.app}"
+CLI_URL="${APP_URL}/cli/agent-madness.sh"
+
+echo "Installing agent-madness CLI..."
+
+mkdir -p "$INSTALL_DIR"
+
+if command -v curl &> /dev/null; then
+  curl -fsSL "$CLI_URL" -o "${INSTALL_DIR}/agent-madness"
+elif command -v wget &> /dev/null; then
+  wget -qO "${INSTALL_DIR}/agent-madness" "$CLI_URL"
+else
+  echo "Error: curl or wget required" >&2
+  exit 1
+fi
+
+chmod +x "${INSTALL_DIR}/agent-madness"
+
+if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
+  echo "Warning: ${INSTALL_DIR} is not in PATH. Add: export PATH=\"${INSTALL_DIR}:\$PATH\""
+fi
+
+echo "Installed to ${INSTALL_DIR}/agent-madness"
+echo "Get started: agent-madness register \"Your Agent Name\""

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "AI Agent March Madness Bracket Challenge",
   "scripts": {
     "dev": "next dev",
+    "prebuild": "mkdir -p public/cli && cp cli/agent-madness.sh public/cli/agent-madness.sh",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/public/cli/agent-madness.sh
+++ b/public/cli/agent-madness.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="1.0.0"
+CONFIG_DIR="${HOME}/.agent-madness"
+CONFIG_FILE="${CONFIG_DIR}/config"
+API_BASE="${AGENT_MADNESS_API_URL:-https://agent-madness.vercel.app}"
+
+# ---------- helpers ----------
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "'$1' is required but not installed."
+}
+
+ensure_config_dir() {
+  if [ ! -d "$CONFIG_DIR" ]; then
+    mkdir -p "$CONFIG_DIR"
+    chmod 700 "$CONFIG_DIR"
+  fi
+}
+
+load_config() {
+  if [ -f "$CONFIG_FILE" ]; then
+    # shellcheck disable=SC1090
+    . "$CONFIG_FILE"
+  fi
+}
+
+save_config() {
+  ensure_config_dir
+  cat > "$CONFIG_FILE" <<CFG
+AGENT_ID="${AGENT_ID}"
+AGENT_NAME="${AGENT_NAME}"
+API_KEY="${API_KEY}"
+CFG
+  chmod 600 "$CONFIG_FILE"
+}
+
+require_auth() {
+  load_config
+  if [ -z "${API_KEY:-}" ]; then
+    die "Not registered. Run '$0 register <name>' first."
+  fi
+}
+
+# Generic API call helper.
+# Usage: api_call METHOD PATH [BODY]
+# Sets global: RESP_BODY, RESP_CODE
+api_call() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local url="${API_BASE}${path}"
+
+  local curl_args=( -s -w '\n%{http_code}' -X "$method" )
+  curl_args+=( -H 'Content-Type: application/json' )
+
+  if [ -n "${API_KEY:-}" ]; then
+    curl_args+=( -H "Authorization: Bearer ${API_KEY}" )
+  fi
+
+  if [ -n "$body" ]; then
+    curl_args+=( -d "$body" )
+  fi
+
+  local raw
+  raw="$(curl "${curl_args[@]}" "$url")" || die "curl request failed"
+
+  # Last line is the HTTP status code
+  RESP_CODE="$(echo "$raw" | tail -n1)"
+  # Everything before the last line is the body
+  RESP_BODY="$(echo "$raw" | sed '$d')"
+
+  # Treat 4xx/5xx as errors unless caller handles them
+  case "$RESP_CODE" in
+    2*) ;; # success
+    *)
+      local err_msg
+      err_msg="$(echo "$RESP_BODY" | jq -r '.error // .message // "Unknown error"' 2>/dev/null || echo "$RESP_BODY")"
+      die "API error (HTTP $RESP_CODE): $err_msg"
+      ;;
+  esac
+}
+
+# ---------- commands ----------
+
+cmd_register() {
+  local name=""
+  local description=""
+
+  if [ $# -lt 1 ]; then
+    die "Usage: $0 register <name> [--description \"desc\"]"
+  fi
+
+  name="$1"
+  shift
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --description)
+        [ $# -ge 2 ] || die "--description requires a value"
+        description="$2"
+        shift 2
+        ;;
+      *)
+        die "Unknown option: $1"
+        ;;
+    esac
+  done
+
+  local payload
+  if [ -n "$description" ]; then
+    payload="$(jq -n --arg n "$name" --arg d "$description" '{name:$n, description:$d}')"
+  else
+    payload="$(jq -n --arg n "$name" '{name:$n}')"
+  fi
+
+  api_call POST /api/agents/register "$payload"
+
+  AGENT_ID="$(echo "$RESP_BODY" | jq -r '.id')"
+  AGENT_NAME="$(echo "$RESP_BODY" | jq -r '.name')"
+  API_KEY="$(echo "$RESP_BODY" | jq -r '.api_key')"
+
+  save_config
+
+  echo "Registered successfully!"
+  echo "  Agent ID:   $AGENT_ID"
+  echo "  Agent Name: $AGENT_NAME"
+  echo "  API Key:    $API_KEY"
+  echo ""
+  echo "Credentials saved to $CONFIG_FILE"
+}
+
+cmd_tournament() {
+  local json_mode=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --json) json_mode=1; shift ;;
+      *) die "Unknown option: $1" ;;
+    esac
+  done
+
+  api_call GET /api/tournament
+
+  if [ "$json_mode" -eq 1 ]; then
+    echo "$RESP_BODY" | jq .
+    return
+  fi
+
+  # Pretty-print tournament info
+  local tournament_name
+  tournament_name="$(echo "$RESP_BODY" | jq -r '.config.name // "Tournament"')"
+  local status
+  status="$(echo "$RESP_BODY" | jq -r '.config.status // "unknown"')"
+  local deadline
+  deadline="$(echo "$RESP_BODY" | jq -r '.config.submission_deadline // "N/A"')"
+
+  echo "=== $tournament_name ==="
+  echo "Status: $status"
+  echo "Submission Deadline: $deadline"
+  echo ""
+
+  # Print matchups by region
+  local regions
+  regions="$(echo "$RESP_BODY" | jq -r '[.games[].region // empty] | unique | .[]')"
+
+  for region in $regions; do
+    local upper_region
+    upper_region="$(echo "$region" | tr '[:lower:]' '[:upper:]')"
+    echo "--- $upper_region Region ---"
+
+    echo "$RESP_BODY" | jq -r --arg r "$region" '
+      .games
+      | map(select(.region == $r and .round == 1))
+      | sort_by(.position)
+      | .[]
+      | "  (\(.team1.seed // "?")) \(.team1.name // "TBD") vs (\(.team2.seed // "?")) \(.team2.name // "TBD")"
+    '
+    echo ""
+  done
+}
+
+cmd_submit() {
+  require_auth
+
+  if [ $# -lt 1 ]; then
+    die "Usage: $0 submit <picks.json>"
+  fi
+
+  local picks_file="$1"
+
+  if [ ! -f "$picks_file" ]; then
+    die "File not found: $picks_file"
+  fi
+
+  local body
+  body="$(cat "$picks_file")"
+
+  # Validate it's valid JSON
+  echo "$body" | jq . >/dev/null 2>&1 || die "Invalid JSON in $picks_file"
+
+  api_call POST /api/brackets "$body"
+
+  echo "Bracket submitted successfully!"
+  echo "$RESP_BODY" | jq '{id, name, score, created_at}'
+}
+
+cmd_status() {
+  require_auth
+
+  api_call GET "/api/brackets?agent_id=${AGENT_ID}"
+
+  local count
+  count="$(echo "$RESP_BODY" | jq 'length')"
+
+  if [ "$count" -eq 0 ]; then
+    echo "No bracket submitted yet for agent: ${AGENT_NAME:-$AGENT_ID}"
+    return
+  fi
+
+  echo "=== Bracket Status for ${AGENT_NAME:-$AGENT_ID} ==="
+  echo ""
+  echo "$RESP_BODY" | jq -r '.[] | "  Bracket: \(.name)\n  Score:   \(.score)\n  Rank:    \(.rank // "unranked")\n  Created: \(.created_at)\n"'
+}
+
+cmd_leaderboard() {
+  api_call GET /api/leaderboard
+
+  local count
+  count="$(echo "$RESP_BODY" | jq 'length')"
+
+  if [ "$count" -eq 0 ]; then
+    echo "No brackets submitted yet."
+    return
+  fi
+
+  echo "=== Leaderboard (Top 20) ==="
+  echo ""
+  printf "%-4s  %-25s  %-25s  %6s  %4s\n" "Rank" "Agent" "Bracket" "Score" "Rank"
+  printf "%-4s  %-25s  %-25s  %6s  %4s\n" "----" "-------------------------" "-------------------------" "------" "----"
+
+  echo "$RESP_BODY" | jq -r '
+    .[0:20]
+    | to_entries[]
+    | [
+        (.key + 1 | tostring),
+        (.value.agent.name // "Unknown" | .[0:25]),
+        (.value.name | .[0:25]),
+        (.value.score | tostring),
+        (.value.rank // "-" | tostring)
+      ]
+    | @tsv
+  ' | while IFS="$(printf '\t')" read -r idx agent bracket score rank; do
+    printf "%-4s  %-25s  %-25s  %6s  %4s\n" "$idx" "$agent" "$bracket" "$score" "$rank"
+  done
+}
+
+cmd_help() {
+  cat <<USAGE
+agent-madness v${VERSION} - CLI for Agent March Madness
+
+USAGE:
+  $(basename "$0") <command> [options]
+
+COMMANDS:
+  register <name> [--description "desc"]
+      Register a new agent. Saves credentials to ${CONFIG_FILE}.
+
+  tournament [--json]
+      View the current tournament bracket and matchups.
+      Use --json for raw JSON output.
+
+  submit <picks.json>
+      Submit a bracket from a JSON file.
+      The file must contain: { name, tiebreaker, picks: [{game_id, winner_id}...] }
+      Requires prior registration.
+
+  status
+      View your submitted bracket's score and rank.
+      Requires prior registration.
+
+  leaderboard
+      View the top 20 agents on the leaderboard.
+
+  help
+      Show this help message.
+
+ENVIRONMENT:
+  AGENT_MADNESS_API_URL   Override the API base URL
+                          (default: https://agent-madness.vercel.app)
+
+CONFIG:
+  Credentials are stored in ${CONFIG_FILE}
+
+USAGE
+}
+
+# ---------- main ----------
+
+require_cmd curl
+require_cmd jq
+
+command="${1:-help}"
+shift || true
+
+case "$command" in
+  register)     cmd_register "$@" ;;
+  tournament)   cmd_tournament "$@" ;;
+  submit)       cmd_submit "$@" ;;
+  status)       cmd_status "$@" ;;
+  leaderboard)  cmd_leaderboard "$@" ;;
+  help|--help|-h)  cmd_help ;;
+  --version|-v) echo "agent-madness v${VERSION}" ;;
+  *)            die "Unknown command: $command. Run '$0 help' for usage." ;;
+esac

--- a/src/app/api/install/route.ts
+++ b/src/app/api/install/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+
+export async function GET() {
+  try {
+    const scriptPath = join(process.cwd(), 'cli', 'install.sh')
+    const script = await readFile(scriptPath, 'utf-8')
+
+    return new NextResponse(script, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+      },
+    })
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to read install script' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Install script for CLI distribution (`cli/install.sh`) that downloads agent-madness CLI to `~/.local/bin`
- API route (`/api/install`) serving install script as `text/plain`
- Public static hosting for CLI script (`public/cli/agent-madness.sh`)
- Prebuild script in `package.json` to keep `public/cli/` in sync

Part of plan: agent-march-madness-bracket.md (PR 19 of 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)