### PR TITLE
Fix: pass adminSecret prop to GameResultForm in admin page

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -250,6 +250,7 @@ export default function AdminPage() {
         {!loading && !error && (
           <GameResultForm
             games={roundGames}
+            adminSecret={adminSecret}
             onResultSubmitted={fetchGames}
           />
         )}


### PR DESCRIPTION
## Summary
- Fixes TypeScript error where `adminSecret` prop was missing from the `GameResultForm` component in the admin page
- The `GameResultForm` requires `adminSecret` to authenticate POST requests to `/api/admin/results`

Part of plan: agent-march-madness-bracket.md (PR 17 of 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)