### PR TITLE
fix: secure agent API keys from public RLS exposure

### DIFF
--- a/scripts/seed-tournament.ts
+++ b/scripts/seed-tournament.ts
@@ -86,8 +86,31 @@ async function seed() {
   }
   console.log('Tournament config upserted.')
 
-  // ─── 2. Delete existing games and teams (for idempotency) ─────────────────
-  // Games reference teams, so delete games first.
+  // ─── 2. Delete existing data (for idempotency) ──────────────────────────
+  // Delete in FK-safe order: picks → brackets → games → teams.
+  // picks.game_id references games without CASCADE, so picks must go first.
+  // brackets.agent_id has CASCADE but games have self-referential FKs
+  // (feed_game_1_id, feed_game_2_id) without CASCADE.
+
+  const { error: deletePicksError } = await supabase
+    .from('picks')
+    .delete()
+    .gte('id', 0) // matches all rows
+
+  if (deletePicksError) {
+    console.error('Failed to delete existing picks:', deletePicksError)
+    process.exit(1)
+  }
+
+  const { error: deleteBracketsError } = await supabase
+    .from('brackets')
+    .delete()
+    .gte('id', '00000000-0000-0000-0000-000000000000') // matches all UUID rows
+
+  if (deleteBracketsError) {
+    console.error('Failed to delete existing brackets:', deleteBracketsError)
+    process.exit(1)
+  }
 
   const { error: deleteGamesError } = await supabase
     .from('games')
@@ -109,7 +132,7 @@ async function seed() {
     process.exit(1)
   }
 
-  console.log('Cleared existing teams and games.')
+  console.log('Cleared existing picks, brackets, games, and teams.')
 
   // ─── 3. Insert teams ─────────────────────────────────────────────────────
 

--- a/src/app/agents/[id]/page.tsx
+++ b/src/app/agents/[id]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({
   const { id } = await params;
   const supabase = await createClient();
   const { data: agent } = await supabase
-    .from("agents")
+    .from("agents_public")
     .select("name")
     .eq("id", id)
     .single();
@@ -103,7 +103,7 @@ export default async function AgentProfilePage({ params }: AgentProfileProps) {
 
   // Fetch agent
   const { data: agent } = await supabase
-    .from("agents")
+    .from("agents_public")
     .select("*")
     .eq("id", id)
     .single<Agent>();

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
   // Fetch brackets joined with agents, ordered by score DESC, rank ASC
   const { data: brackets, error: bracketsError } = await supabase
     .from('brackets')
-    .select('*, agent:agents(id, name, avatar_url)')
+    .select('*, agent:agents_public(id, name, avatar_url)')
     .order('score', { ascending: false })
     .order('rank', { ascending: true })
 

--- a/src/app/brackets/[id]/page.tsx
+++ b/src/app/brackets/[id]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({
   const supabase = await createClient();
   const { data: bracket } = await supabase
     .from("brackets")
-    .select("name, agent:agents ( name )")
+    .select("name, agent:agents_public ( name )")
     .eq("id", id)
     .single();
 
@@ -95,7 +95,7 @@ export default async function BracketDetailPage({
     .select(
       `
       *,
-      agent:agents ( id, name, avatar_url, description ),
+      agent:agents_public ( id, name, avatar_url, description ),
       picks (
         *,
         predicted_winner:teams!picks_predicted_winner_id_fkey (*)

--- a/src/app/brackets/page.tsx
+++ b/src/app/brackets/page.tsx
@@ -23,7 +23,7 @@ export default async function BracketsPage() {
       rank,
       tiebreaker,
       created_at,
-      agent:agents ( id, name, avatar_url )
+      agent:agents_public ( id, name, avatar_url )
     `
     )
     .order("score", { ascending: false });

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -15,7 +15,7 @@ export default async function LeaderboardPage() {
   // Fetch brackets joined with agents, ordered by score DESC
   const { data: brackets } = await supabase
     .from("brackets")
-    .select("*, agent:agents(id, name, avatar_url)")
+    .select("*, agent:agents_public(id, name, avatar_url)")
     .order("score", { ascending: false })
     .order("rank", { ascending: true });
 

--- a/supabase/migrations/20260316000001_secure_agent_keys.sql
+++ b/supabase/migrations/20260316000001_secure_agent_keys.sql
@@ -1,0 +1,15 @@
+-- Secure agent API keys from public access
+-- The existing "Public read agents" policy exposes api_key to anyone
+-- querying via the Supabase anon key. Since RLS is row-level only and
+-- cannot restrict columns, we use a view to expose only safe columns.
+
+-- 1. Drop the overly permissive public read policy on agents
+DROP POLICY "Public read agents" ON agents;
+
+-- 2. Create a public view that excludes the api_key column
+CREATE VIEW agents_public AS
+  SELECT id, name, avatar_url, description, created_at
+  FROM agents;
+
+-- 3. Grant SELECT on the view to anon and authenticated roles
+GRANT SELECT ON agents_public TO anon, authenticated;


### PR DESCRIPTION
## Summary
- Create migration to drop public SELECT policy on agents table, replacing with a secure `agents_public` view that excludes `api_key`
- Update all browser-facing and anon-key queries to use `agents_public` view instead of `agents` table
- Fix seed script to delete picks and brackets before games/teams to avoid FK violations

Fixes critical security gap where agent API keys were readable via Supabase anon key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)