### PR TITLE
Correct 2026 tournament field and results fixture

### DIFF
--- a/data/results-2026.json
+++ b/data/results-2026.json
@@ -1,0 +1,108 @@
+{
+  "year": 2026,
+  "sources": [
+    {
+      "label": "NCAA official bracket",
+      "url": "https://www.ncaa.com/brackets/basketball-men/d1/2026"
+    },
+    {
+      "label": "Wikipedia completed tournament table",
+      "url": "https://en.wikipedia.org/wiki/2026_NCAA_Division_I_men%27s_basketball_tournament"
+    }
+  ],
+  "field_corrections": [
+    {
+      "region": "midwest",
+      "seed": 16,
+      "from_short_name": "UMBC",
+      "to": { "name": "Howard Bison", "short_name": "Howard" }
+    },
+    {
+      "region": "midwest",
+      "seed": 11,
+      "from_short_name": "SMU",
+      "to": { "name": "Miami RedHawks", "short_name": "Miami (OH)" }
+    }
+  ],
+  "final_four_feed_order": [
+    {
+      "position": 1,
+      "feeders": [
+        { "region": "east", "round": 4, "position": 1 },
+        { "region": "south", "round": 4, "position": 1 }
+      ]
+    },
+    {
+      "position": 2,
+      "feeders": [
+        { "region": "west", "round": 4, "position": 1 },
+        { "region": "midwest", "round": 4, "position": 1 }
+      ]
+    }
+  ],
+  "results": [
+    { "round": 1, "region": "east", "position": 1, "winner_short_name": "Duke" },
+    { "round": 1, "region": "east", "position": 2, "winner_short_name": "TCU" },
+    { "round": 1, "region": "east", "position": 3, "winner_short_name": "St John's" },
+    { "round": 1, "region": "east", "position": 4, "winner_short_name": "Kansas" },
+    { "round": 1, "region": "east", "position": 5, "winner_short_name": "Louisville" },
+    { "round": 1, "region": "east", "position": 6, "winner_short_name": "Mich St" },
+    { "round": 1, "region": "east", "position": 7, "winner_short_name": "UCLA" },
+    { "round": 1, "region": "east", "position": 8, "winner_short_name": "UConn" },
+    { "round": 1, "region": "west", "position": 1, "winner_short_name": "Arizona" },
+    { "round": 1, "region": "west", "position": 2, "winner_short_name": "Utah St" },
+    { "round": 1, "region": "west", "position": 3, "winner_short_name": "High Point" },
+    { "round": 1, "region": "west", "position": 4, "winner_short_name": "Arkansas" },
+    { "round": 1, "region": "west", "position": 5, "winner_short_name": "Texas" },
+    { "round": 1, "region": "west", "position": 6, "winner_short_name": "Gonzaga" },
+    { "round": 1, "region": "west", "position": 7, "winner_short_name": "Miami FL" },
+    { "round": 1, "region": "west", "position": 8, "winner_short_name": "Purdue" },
+    { "round": 1, "region": "midwest", "position": 1, "winner_short_name": "Michigan" },
+    { "round": 1, "region": "midwest", "position": 2, "winner_short_name": "Saint Louis" },
+    { "round": 1, "region": "midwest", "position": 3, "winner_short_name": "Texas Tech" },
+    { "round": 1, "region": "midwest", "position": 4, "winner_short_name": "Alabama" },
+    { "round": 1, "region": "midwest", "position": 5, "winner_short_name": "Tennessee" },
+    { "round": 1, "region": "midwest", "position": 6, "winner_short_name": "Virginia" },
+    { "round": 1, "region": "midwest", "position": 7, "winner_short_name": "Kentucky" },
+    { "round": 1, "region": "midwest", "position": 8, "winner_short_name": "Iowa St" },
+    { "round": 1, "region": "south", "position": 1, "winner_short_name": "Florida" },
+    { "round": 1, "region": "south", "position": 2, "winner_short_name": "Iowa" },
+    { "round": 1, "region": "south", "position": 3, "winner_short_name": "Vanderbilt" },
+    { "round": 1, "region": "south", "position": 4, "winner_short_name": "Nebraska" },
+    { "round": 1, "region": "south", "position": 5, "winner_short_name": "VCU" },
+    { "round": 1, "region": "south", "position": 6, "winner_short_name": "Illinois" },
+    { "round": 1, "region": "south", "position": 7, "winner_short_name": "Texas A&M" },
+    { "round": 1, "region": "south", "position": 8, "winner_short_name": "Houston" },
+    { "round": 2, "region": "east", "position": 1, "winner_short_name": "Duke" },
+    { "round": 2, "region": "east", "position": 2, "winner_short_name": "St John's" },
+    { "round": 2, "region": "east", "position": 3, "winner_short_name": "Mich St" },
+    { "round": 2, "region": "east", "position": 4, "winner_short_name": "UConn" },
+    { "round": 2, "region": "west", "position": 1, "winner_short_name": "Arizona" },
+    { "round": 2, "region": "west", "position": 2, "winner_short_name": "Arkansas" },
+    { "round": 2, "region": "west", "position": 3, "winner_short_name": "Texas" },
+    { "round": 2, "region": "west", "position": 4, "winner_short_name": "Purdue" },
+    { "round": 2, "region": "midwest", "position": 1, "winner_short_name": "Michigan" },
+    { "round": 2, "region": "midwest", "position": 2, "winner_short_name": "Alabama" },
+    { "round": 2, "region": "midwest", "position": 3, "winner_short_name": "Tennessee" },
+    { "round": 2, "region": "midwest", "position": 4, "winner_short_name": "Iowa St" },
+    { "round": 2, "region": "south", "position": 1, "winner_short_name": "Iowa" },
+    { "round": 2, "region": "south", "position": 2, "winner_short_name": "Nebraska" },
+    { "round": 2, "region": "south", "position": 3, "winner_short_name": "Illinois" },
+    { "round": 2, "region": "south", "position": 4, "winner_short_name": "Houston" },
+    { "round": 3, "region": "east", "position": 1, "winner_short_name": "Duke" },
+    { "round": 3, "region": "east", "position": 2, "winner_short_name": "UConn" },
+    { "round": 3, "region": "west", "position": 1, "winner_short_name": "Arizona" },
+    { "round": 3, "region": "west", "position": 2, "winner_short_name": "Purdue" },
+    { "round": 3, "region": "midwest", "position": 1, "winner_short_name": "Michigan" },
+    { "round": 3, "region": "midwest", "position": 2, "winner_short_name": "Tennessee" },
+    { "round": 3, "region": "south", "position": 1, "winner_short_name": "Iowa" },
+    { "round": 3, "region": "south", "position": 2, "winner_short_name": "Illinois" },
+    { "round": 4, "region": "east", "position": 1, "winner_short_name": "UConn" },
+    { "round": 4, "region": "west", "position": 1, "winner_short_name": "Arizona" },
+    { "round": 4, "region": "midwest", "position": 1, "winner_short_name": "Michigan" },
+    { "round": 4, "region": "south", "position": 1, "winner_short_name": "Illinois" },
+    { "round": 5, "region": null, "position": 1, "winner_short_name": "UConn" },
+    { "round": 5, "region": null, "position": 2, "winner_short_name": "Michigan" },
+    { "round": 6, "region": null, "position": 1, "winner_short_name": "Michigan" }
+  ]
+}

--- a/data/tournament-2026.json
+++ b/data/tournament-2026.json
@@ -50,12 +50,12 @@
       "8": { "name": "Georgia Bulldogs", "short_name": "Georgia" },
       "9": { "name": "Saint Louis Billikens", "short_name": "Saint Louis" },
       "10": { "name": "Santa Clara Broncos", "short_name": "Santa Clara" },
-      "11": { "name": "SMU Mustangs", "short_name": "SMU" },
+      "11": { "name": "Miami RedHawks", "short_name": "Miami (OH)" },
       "12": { "name": "Akron Zips", "short_name": "Akron" },
       "13": { "name": "Hofstra Pride", "short_name": "Hofstra" },
       "14": { "name": "Wright State Raiders", "short_name": "Wright St" },
       "15": { "name": "Tennessee State Tigers", "short_name": "Tenn St" },
-      "16": { "name": "UMBC Retrievers", "short_name": "UMBC" }
+      "16": { "name": "Howard Bison", "short_name": "Howard" }
     },
     "south": {
       "1": { "name": "Florida Gators", "short_name": "Florida" },

--- a/public/team-logos/default.svg
+++ b/public/team-logos/default.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Default team logo</title>
+  <desc id="desc">Generic basketball placeholder logo.</desc>
+  <rect width="128" height="128" rx="28" fill="#f3f4f6"/>
+  <circle cx="64" cy="64" r="42" fill="#f97316"/>
+  <path d="M24 64h80M64 22v84M34 36c18 18 42 18 60 0M34 92c18-18 42-18 60 0" fill="none" stroke="#7c2d12" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="64" cy="64" r="42" fill="none" stroke="#111827" stroke-width="4"/>
+</svg>

--- a/public/team-logos/howard.svg
+++ b/public/team-logos/howard.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Howard Bison logo placeholder</title>
+  <desc id="desc">Simple Howard Bison placeholder mark.</desc>
+  <rect width="128" height="128" rx="28" fill="#002855"/>
+  <circle cx="64" cy="64" r="46" fill="#ffffff"/>
+  <circle cx="64" cy="64" r="38" fill="#e51937"/>
+  <text x="64" y="78" text-anchor="middle" font-family="Georgia, serif" font-size="48" font-weight="700" fill="#ffffff">H</text>
+</svg>

--- a/public/team-logos/miami-oh.svg
+++ b/public/team-logos/miami-oh.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Miami RedHawks logo placeholder</title>
+  <desc id="desc">Simple Miami Ohio RedHawks placeholder mark.</desc>
+  <rect width="128" height="128" rx="28" fill="#b61e2e"/>
+  <path d="M24 88V40h18l22 25 22-25h18v48H86V62L64 88 42 62v26z" fill="#ffffff"/>
+  <path d="M24 40h18l22 25 22-25h18" fill="none" stroke="#111827" stroke-width="4" stroke-linejoin="round"/>
+</svg>

--- a/scripts/seed-tournament.ts
+++ b/scripts/seed-tournament.ts
@@ -314,8 +314,8 @@ async function seed() {
   console.log('Round 4 (E8) games inserted.')
 
   // ── Round 5 (Final Four): 2 games, region=NULL ────────────────────────────
-  // Position 1: East winner vs West winner
-  // Position 2: Midwest winner vs South winner
+  // Position 1: East winner vs South winner
+  // Position 2: West winner vs Midwest winner
 
   const f4Rows = [
     {
@@ -323,14 +323,14 @@ async function seed() {
       region: null,
       position: 1,
       feed_game_1_id: gameIdMap['4-east-1'],
-      feed_game_2_id: gameIdMap['4-west-1'],
+      feed_game_2_id: gameIdMap['4-south-1'],
     },
     {
       round: 5,
       region: null,
       position: 2,
-      feed_game_1_id: gameIdMap['4-midwest-1'],
-      feed_game_2_id: gameIdMap['4-south-1'],
+      feed_game_1_id: gameIdMap['4-west-1'],
+      feed_game_2_id: gameIdMap['4-midwest-1'],
     },
   ]
 

--- a/src/lib/team-logos.ts
+++ b/src/lib/team-logos.ts
@@ -45,12 +45,12 @@ const TEAM_LOGO_MAP: Record<string, string> = {
   "Georgia": "georgia.png",
   "Saint Louis": "saint-louis.png",
   "Santa Clara": "santa-clara.png",
-  "SMU": "smu.png",
+  "Miami (OH)": "miami-oh.svg",
   "Akron": "akron.png",
   "Hofstra": "hofstra.png",
   "Wright St": "wright-st.png",
   "Tenn St": "tenn-st.png",
-  "UMBC": "umbc.png",
+  "Howard": "howard.svg",
   // SOUTH REGION
   "Florida": "florida.png",
   "Houston": "houston.png",
@@ -72,7 +72,7 @@ const TEAM_LOGO_MAP: Record<string, string> = {
 
 export function getTeamLogoPath(shortName: string): string {
   const filename = TEAM_LOGO_MAP[shortName];
-  if (!filename) return '/team-logos/default.png';
+  if (!filename) return '/team-logos/default.svg';
   return `/team-logos/${filename}`;
 }
 


### PR DESCRIPTION
## Summary
- Corrects the 2026 main-bracket play-in slots from placeholder First Four entrants to Howard and Miami (OH).
- Updates 2026 Final Four topology to East-vs-South and West-vs-Midwest.
- Adds an audited 63-game results fixture for the completed 2026 tournament.
- Adds logo fallback assets for corrected teams.

## Verification
- Parsed `data/results-2026.json` and verified 63 unique result keys.

Part of #93. Closes #94.
